### PR TITLE
Add daily auto-run feature for difficulty tagging

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,5 +10,9 @@
   "easy_ease_min_pct": 250,
 
   "very_easy_ivl_min": 90,
-  "very_easy_ease_min_pct": 280
+  "very_easy_ease_min_pct": 280,
+
+  "auto_run_daily": false,
+  "auto_run_search": "",
+  "last_auto_run_ymd": ""
 }


### PR DESCRIPTION
Introduces an option to auto-run the difficulty tagging process once per day when an Anki profile is opened. Adds new config options for enabling auto-run, specifying a search query, and tracking the last run date. Updates the config dialog to support these settings and ensures unknown config keys are preserved.